### PR TITLE
(WIP) Persistency

### DIFF
--- a/abracadabra/nain4/nain4.hh
+++ b/abracadabra/nain4/nain4.hh
@@ -11,6 +11,7 @@
 #include <G4ParticleTable.hh>
 #include <G4PhysicalVolumeStore.hh>
 #include <G4RotationMatrix.hh>
+#include <G4Run.hh>
 #include <G4RunManager.hh>
 #include <G4String.hh>
 #include <G4SolidStore.hh>
@@ -52,6 +53,8 @@ IA find_logical  NAME_VRB { return G4LogicalVolumeStore ::GetInstance()->GetVolu
 IA find_physical NAME_VRB { return G4PhysicalVolumeStore::GetInstance()->GetVolume          (name, verbose); }
 IA find_solid    NAME_VRB { return G4SolidStore         ::GetInstance()->GetSolid           (name, verbose); }
 IA find_particle NAME     { return G4ParticleTable:: GetParticleTable()->FindParticle       (name         ); }
+
+IA event_number  ()       { return G4RunManager::GetRunManager()->GetCurrentRun()->GetNumberOfEvent(); }
 #undef IA
 #undef NAME
 #undef NAME_VRB

--- a/abracadabra/src/g4-mandatory/event_action.cc
+++ b/abracadabra/src/g4-mandatory/event_action.cc
@@ -1,17 +1,29 @@
 #include "event_action.hh"
 #include "run_action.hh"
 
+#include "io/hdf5.hh"
+
 #include <G4Event.hh>
 #include <G4RunManager.hh>
 
 event_action::event_action(run_action* runAction)
 : G4UserEventAction()
 , action(runAction)
-, edep(0) {}
+, edep(0)
+, data{} {}
 
 void event_action::BeginOfEventAction(const G4Event*) { edep = 0; }
 
 void event_action::EndOfEventAction(const G4Event*) {
   // accumulate statistics in run action
   action->AddEdep(edep);
+  action->next_event();
+  std::cout << "event id: " << action->get_evt_number() << std::endl;
+
+  for (auto hit: data.get_hits()){
+    auto pos  = hit.GetPreStepPoint() -> GetPosition();
+    auto time = hit.GetPreStepPoint() -> GetGlobalTime();
+	std::cout << "time: " << time << std::endl;
+
+  }
 }

--- a/abracadabra/src/g4-mandatory/event_action.cc
+++ b/abracadabra/src/g4-mandatory/event_action.cc
@@ -9,14 +9,10 @@
 event_action::event_action(run_action* runAction)
 : G4UserEventAction()
 , action(runAction)
-, edep(0)
 , data{} {}
-
-void event_action::BeginOfEventAction(const G4Event*) { edep = 0; }
 
 void event_action::EndOfEventAction(const G4Event*) {
   // accumulate statistics in run action
-  action->AddEdep(edep);
   action->next_event();
   std::cout << "event id: " << action->get_evt_number() << std::endl;
 

--- a/abracadabra/src/g4-mandatory/event_action.cc
+++ b/abracadabra/src/g4-mandatory/event_action.cc
@@ -11,16 +11,14 @@
 
 event_action::event_action(run_action* runAction)
 : G4UserEventAction()
-, action(runAction)
-, data{} {}
+, action(runAction) {}
 
-void event_action::EndOfEventAction(const G4Event*) {
-  // accumulate statistics in run action
-  std::cout << "event id: " << nain4::event_number() << std::endl;
+void event_action::EndOfEventAction(const G4Event* event) {
+  auto evt_data = dynamic_cast<event_data*>(event -> GetUserInformation());
 
-  for (auto hit: data.get_hits()) {
+  for (auto hit: evt_data->get_hits()) {
     auto pos  = hit.GetPreStepPoint() -> GetPosition();
     auto time = hit.GetPreStepPoint() -> GetGlobalTime();
-    std::cout << "time: " << time << std::endl;
+    //TODO: Decide whether to write here or in sensitive detector
   }
 }

--- a/abracadabra/src/g4-mandatory/event_action.cc
+++ b/abracadabra/src/g4-mandatory/event_action.cc
@@ -2,9 +2,12 @@
 #include "run_action.hh"
 
 #include "io/hdf5.hh"
+#include "nain4.hh"
 
 #include <G4Event.hh>
+#include <G4Run.hh>
 #include <G4RunManager.hh>
+
 
 event_action::event_action(run_action* runAction)
 : G4UserEventAction()
@@ -13,13 +16,11 @@ event_action::event_action(run_action* runAction)
 
 void event_action::EndOfEventAction(const G4Event*) {
   // accumulate statistics in run action
-  action->next_event();
-  std::cout << "event id: " << action->get_evt_number() << std::endl;
+  std::cout << "event id: " << nain4::event_number() << std::endl;
 
-  for (auto hit: data.get_hits()){
+  for (auto hit: data.get_hits()) {
     auto pos  = hit.GetPreStepPoint() -> GetPosition();
     auto time = hit.GetPreStepPoint() -> GetGlobalTime();
-	std::cout << "time: " << time << std::endl;
-
+    std::cout << "time: " << time << std::endl;
   }
 }

--- a/abracadabra/src/g4-mandatory/event_action.hh
+++ b/abracadabra/src/g4-mandatory/event_action.hh
@@ -19,7 +19,7 @@ public:
 
   void Print() const override {};
 
-  void set_hits(std::vector<G4Step>& sensor_hits) { hits = sensor_hits; }
+  void set_hits(std::vector<G4Step>&& sensor_hits) { hits = std::move(sensor_hits); }
   std::vector<G4Step>& get_hits() { return hits; }
 
 private:
@@ -32,11 +32,10 @@ public:
   event_action(run_action* runAction);
   ~event_action() override {}
 
-  void EndOfEventAction(const G4Event* event) override;
+  void EndOfEventAction  (const G4Event* event) override;
 
 private:
   run_action* action;
-  event_data  data;
 };
 
 

--- a/abracadabra/src/g4-mandatory/event_action.hh
+++ b/abracadabra/src/g4-mandatory/event_action.hh
@@ -4,7 +4,28 @@
 #include <G4UserEventAction.hh>
 #include <globals.hh>
 
+#include <G4VUserEventInformation.hh>
+#include <G4Step.hh>
+#include <vector>
+
 class run_action;
+
+
+// This class is a container to store everything we need to store later for a given event
+class event_data : public G4VUserEventInformation {
+public:
+  event_data() : G4VUserEventInformation(), hits{} {}
+  ~event_data() override {};
+
+  void Print() const override {};
+
+  void set_hits(std::vector<G4Step>& sensor_hits) { hits = sensor_hits; }
+  std::vector<G4Step>& get_hits() { return hits; }
+
+private:
+  std::vector<G4Step> hits;
+};
+
 
 class event_action : public G4UserEventAction {
 public:
@@ -19,6 +40,8 @@ public:
 private:
   run_action* action;
   G4double    edep;
+  event_data  data;
 };
+
 
 #endif

--- a/abracadabra/src/g4-mandatory/event_action.hh
+++ b/abracadabra/src/g4-mandatory/event_action.hh
@@ -32,14 +32,10 @@ public:
   event_action(run_action* runAction);
   ~event_action() override {}
 
-  void BeginOfEventAction(const G4Event* event) override;
   void EndOfEventAction(const G4Event* event) override;
-
-  void AddEdep(G4double edep_) { edep += edep_; }
 
 private:
   run_action* action;
-  G4double    edep;
   event_data  data;
 };
 

--- a/abracadabra/src/g4-mandatory/run_action.cc
+++ b/abracadabra/src/g4-mandatory/run_action.cc
@@ -11,7 +11,7 @@
 #include <G4SystemOfUnits.hh>
 #include <G4UnitsTable.hh>
 
-run_action::run_action() : G4UserRunAction{} , evt_number(0) {}
+run_action::run_action() : G4UserRunAction{} {}
 
 void run_action::BeginOfRunAction(const G4Run*) {
   // inform the runManager to save random number seed

--- a/abracadabra/src/g4-mandatory/run_action.cc
+++ b/abracadabra/src/g4-mandatory/run_action.cc
@@ -11,22 +11,7 @@
 #include <G4SystemOfUnits.hh>
 #include <G4UnitsTable.hh>
 
-run_action::run_action()
-: G4UserRunAction()
-, edep(0)
-, edep2(0)
-, evt_number(0) {
-  // G4 takes ownership of these by *MAGIC*
-  new G4UnitDefinition{"milligray", "milliGy" , "Dose", 1.e-3  * gray};
-  new G4UnitDefinition{"microgray", "microGy" , "Dose", 1.e-6  * gray};
-  new G4UnitDefinition{ "nanogray",  "nanoGy" , "Dose", 1.e-9  * gray};
-  new G4UnitDefinition{ "picogray",  "picoGy" , "Dose", 1.e-12 * gray};
-
-  // Register accumulable to the accumulable manager
-  auto accumulableManager = G4AccumulableManager::Instance();
-  accumulableManager -> RegisterAccumulable(edep);
-  accumulableManager -> RegisterAccumulable(edep2);
-}
+run_action::run_action() : G4UserRunAction{} , evt_number(0) {}
 
 void run_action::BeginOfRunAction(const G4Run*) {
   // inform the runManager to save random number seed
@@ -36,58 +21,8 @@ void run_action::BeginOfRunAction(const G4Run*) {
   G4AccumulableManager::Instance() -> Reset();
 }
 
-
 void run_action::EndOfRunAction(const G4Run* run) {
   G4int nofEvents = run -> GetNumberOfEvent();
   if (nofEvents == 0) return;
 
-  // Merge accumulables
-  auto accumulableManager = G4AccumulableManager::Instance();
-  accumulableManager -> Merge();
-
-  // Compute dose = total energy deposit in a run and its variance
-  G4double edep_  = this -> edep .GetValue();
-  G4double edep2_ = this -> edep2.GetValue();
-
-  G4double rms = edep2_ - edep_ * edep_ / nofEvents;
-  if (rms > 0) rms = std::sqrt(rms); else rms = 0;
-
-  const auto* detector = static_cast<const detector_construction*>
-     (G4RunManager::GetRunManager() -> GetUserDetectorConstruction());
-  // G4double    mass = detector -> GetScoringVolume() -> GetMass();
-  // G4double    dose = edep_ / mass;
-  // G4double rmsDose = rms  / mass;
-
-  // Run conditions
-  //  note: There is no primary generator action object for "master"
-  //        run manager for multi-threaded mode.
-  const auto* generator = static_cast<const primary_generator_action*>
-     (G4RunManager::GetRunManager() -> GetUserPrimaryGeneratorAction());
-  G4String runCondition;
-  if (generator) {
-    auto const& particleGun = generator -> get_particle_gun();
-    runCondition += particleGun.GetParticleDefinition() -> GetParticleName();
-    runCondition += " of ";
-    G4double particleEnergy = particleGun.GetParticleEnergy();
-    runCondition += G4BestUnit(particleEnergy, "Energy");
-  }
-
-  // Print
-  if (IsMaster()) {
-    G4cout << G4endl << "--------------------End of Global Run-----------------------";
-  } else {
-    G4cout << G4endl << "--------------------End of Local Run------------------------";
-  }
-
-  // G4cout                                                                   << G4endl
-  //    << " The run consists of " << nofEvents << " " << runCondition        << G4endl
-  //    << " Cumulated dose per run, in scoring volume : "
-  //    << G4BestUnit(dose,"Dose") << " rms = " << G4BestUnit(rmsDose,"Dose") << G4endl
-  //    << "------------------------------------------------------------"     << G4endl << G4endl;
-}
-
-
-void run_action::AddEdep(G4double edep_) {
-  this -> edep  += edep_;
-  this -> edep2 += edep_ * edep_;
 }

--- a/abracadabra/src/g4-mandatory/run_action.cc
+++ b/abracadabra/src/g4-mandatory/run_action.cc
@@ -14,7 +14,8 @@
 run_action::run_action()
 : G4UserRunAction()
 , edep(0)
-, edep2(0) {
+, edep2(0)
+, evt_number(0) {
   // G4 takes ownership of these by *MAGIC*
   new G4UnitDefinition{"milligray", "milliGy" , "Dose", 1.e-3  * gray};
   new G4UnitDefinition{"microgray", "microGy" , "Dose", 1.e-6  * gray};

--- a/abracadabra/src/g4-mandatory/run_action.hh
+++ b/abracadabra/src/g4-mandatory/run_action.hh
@@ -21,10 +21,13 @@ public:
   void   EndOfRunAction(const G4Run*) override;
 
   void AddEdep (G4double edep);
+  void next_event() {evt_number++; }
+  unsigned int get_evt_number() { return evt_number; }
 
 private:
   G4Accumulable<G4double> edep;
   G4Accumulable<G4double> edep2;
+  unsigned int evt_number;
 };
 
 #endif

--- a/abracadabra/src/g4-mandatory/run_action.hh
+++ b/abracadabra/src/g4-mandatory/run_action.hh
@@ -19,12 +19,6 @@ public:
   // G4Run* GenerateRun() override;
   void BeginOfRunAction(const G4Run*) override;
   void   EndOfRunAction(const G4Run*) override;
-
-  void next_event() { evt_number++; }
-  unsigned int get_evt_number() { return evt_number; }
-
-private:
-  unsigned int evt_number;
 };
 
 #endif

--- a/abracadabra/src/g4-mandatory/run_action.hh
+++ b/abracadabra/src/g4-mandatory/run_action.hh
@@ -20,13 +20,10 @@ public:
   void BeginOfRunAction(const G4Run*) override;
   void   EndOfRunAction(const G4Run*) override;
 
-  void AddEdep (G4double edep);
-  void next_event() {evt_number++; }
+  void next_event() { evt_number++; }
   unsigned int get_evt_number() { return evt_number; }
 
 private:
-  G4Accumulable<G4double> edep;
-  G4Accumulable<G4double> edep2;
   unsigned int evt_number;
 };
 

--- a/abracadabra/src/g4-mandatory/stepping_action.cc
+++ b/abracadabra/src/g4-mandatory/stepping_action.cc
@@ -10,26 +10,4 @@
 stepping_action::stepping_action(event_action* action)
 : G4UserSteppingAction()
 , action(action)
-, scoring_volume(nullptr) {}
-
-void stepping_action::UserSteppingAction(const G4Step* step) {
-  if (!scoring_volume) {
-    const detector_construction* detectorConstruction
-      = static_cast<const detector_construction*>
-      (G4RunManager::GetRunManager() -> GetUserDetectorConstruction());
-    scoring_volume = detectorConstruction -> GetScoringVolume();
-  }
-
-  // get volume of the current step
-  G4LogicalVolume* volume =
-    step
-    -> GetPreStepPoint()
-    -> GetTouchableHandle()
-    -> GetVolume()
-    -> GetLogicalVolume();
-
-  if (volume == scoring_volume) {
-    // collect energy deposited in this step
-    action -> AddEdep(step -> GetTotalEnergyDeposit());
-  }
-}
+{}

--- a/abracadabra/src/g4-mandatory/stepping_action.hh
+++ b/abracadabra/src/g4-mandatory/stepping_action.hh
@@ -13,11 +13,10 @@ public:
   stepping_action(event_action* eventAction);
   ~stepping_action() override {}
 
-  void UserSteppingAction(const G4Step*) override;
+  //void UserSteppingAction(const G4Step*) override;
 
 private:
-  event_action*    action;
-  G4LogicalVolume* scoring_volume;
+  event_action* action;
 };
 
 #endif

--- a/abracadabra/src/geometries/sipm.cc
+++ b/abracadabra/src/geometries/sipm.cc
@@ -19,7 +19,10 @@ G4LogicalVolume* sipm::build() {
   auto act_half_z = act.dz / 2;
   auto vol_body = volume<G4Box>(    name,     mat,     half.x(),     half.y(),     half.z());
   auto vol_act  = volume<G4Box>(act.name, act.mat, act_half_x  , act_half_y  , act_half_z);
-  vol_act->SetSensitiveDetector(new sipm_sensitive("/does/this/matter?", h5_filename));
+
+  sipm_sensitive sens_det{"/does/this/matter?", h5_filename};
+  sens_det.Activate(true);
+  vol_act->SetSensitiveDetector(&sens_det);
 
   // ----- visibility -------------------------------------------------------------
   vol_body -> SetVisAttributes(    vis_attributes);

--- a/abracadabra/src/geometries/sipm.cc
+++ b/abracadabra/src/geometries/sipm.cc
@@ -23,6 +23,8 @@ G4LogicalVolume* sipm::build() {
   auto sens_det = new sipm_sensitive{"/does/this/matter?", h5_filename};
   sens_det->Activate(true);
   vol_act->SetSensitiveDetector(sens_det);
+  G4SDManager* sdmgr = G4SDManager::GetSDMpointer();
+  sdmgr->AddNewDetector(sens_det);
 
   // ----- visibility -------------------------------------------------------------
   vol_body -> SetVisAttributes(    vis_attributes);
@@ -45,7 +47,7 @@ G4bool sipm_sensitive::ProcessHits(G4Step* step, G4TouchableHistory* /*deprecate
 }
 
 void sipm_sensitive::EndOfEvent(G4HCofThisEvent* hc){
-  std::cout << "end of action" << std::endl;
+  std::cout << "end of event" << std::endl;
   auto current_evt = G4EventManager::GetEventManager()->GetNonconstCurrentEvent();
   auto evt_data = dynamic_cast<event_data*>(current_evt -> GetUserInformation());
   evt_data -> set_hits(hits);

--- a/abracadabra/src/geometries/sipm.cc
+++ b/abracadabra/src/geometries/sipm.cc
@@ -1,8 +1,10 @@
 // clang-format off
 #include "geometries/sipm.hh"
+#include "g4-mandatory/event_action.hh"
 
 #include <G4Box.hh>
 #include <G4LogicalVolume.hh>
+#include <G4EventManager.hh>
 
 using nain4::material_from_elements_N;
 using nain4::place;
@@ -39,7 +41,12 @@ G4bool sipm_sensitive::ProcessHits(G4Step* step, G4TouchableHistory* /*deprecate
   return true; // TODO what is the meaning of this?
 }
 
-
+void sipm_sensitive::EndOfEvent(G4HCofThisEvent* hc){
+  std::cout << "end of action" << std::endl;
+  auto current_evt = G4EventManager::GetEventManager()->GetNonconstCurrentEvent();
+  auto evt_data = dynamic_cast<event_data*>(current_evt -> GetUserInformation());
+  evt_data -> set_hits(hits);
+}
 
 // ------------------------------------------------------------------------------------------
 // Hamamatsu Blue: one example of a SiPM

--- a/abracadabra/src/geometries/sipm.cc
+++ b/abracadabra/src/geometries/sipm.cc
@@ -49,8 +49,10 @@ G4bool sipm_sensitive::ProcessHits(G4Step* step, G4TouchableHistory* /*deprecate
 void sipm_sensitive::EndOfEvent(G4HCofThisEvent* hc){
   std::cout << "end of event" << std::endl;
   auto current_evt = G4EventManager::GetEventManager()->GetNonconstCurrentEvent();
-  auto evt_data = dynamic_cast<event_data*>(current_evt -> GetUserInformation());
-  evt_data -> set_hits(hits);
+  auto data = new event_data{};
+  data -> set_hits(std::move(hits));
+  hits = {};
+  current_evt->SetUserInformation(data);
 }
 
 // ------------------------------------------------------------------------------------------

--- a/abracadabra/src/geometries/sipm.cc
+++ b/abracadabra/src/geometries/sipm.cc
@@ -20,9 +20,9 @@ G4LogicalVolume* sipm::build() {
   auto vol_body = volume<G4Box>(    name,     mat,     half.x(),     half.y(),     half.z());
   auto vol_act  = volume<G4Box>(act.name, act.mat, act_half_x  , act_half_y  , act_half_z);
 
-  sipm_sensitive sens_det{"/does/this/matter?", h5_filename};
-  sens_det.Activate(true);
-  vol_act->SetSensitiveDetector(&sens_det);
+  auto sens_det = new sipm_sensitive{"/does/this/matter?", h5_filename};
+  sens_det->Activate(true);
+  vol_act->SetSensitiveDetector(sens_det);
 
   // ----- visibility -------------------------------------------------------------
   vol_body -> SetVisAttributes(    vis_attributes);

--- a/abracadabra/src/geometries/sipm.cc
+++ b/abracadabra/src/geometries/sipm.cc
@@ -38,7 +38,7 @@ G4bool sipm_sensitive::ProcessHits(G4Step* step, G4TouchableHistory* /*deprecate
   hits.push_back(*step);
   if (io) {
     auto pos  = step -> GetPreStepPoint() -> GetPosition();
-	auto time = step -> GetPreStepPoint() -> GetGlobalTime();
+    auto time = step -> GetPreStepPoint() -> GetGlobalTime();
     io -> write_hit_info(0, pos.getX(), pos.getY(), pos.getZ(), time);
   }
   return true; // TODO what is the meaning of this?

--- a/abracadabra/src/geometries/sipm.cc
+++ b/abracadabra/src/geometries/sipm.cc
@@ -32,8 +32,9 @@ G4LogicalVolume* sipm::build() {
 G4bool sipm_sensitive::ProcessHits(G4Step* step, G4TouchableHistory* /*deprecated_parameter*/) {
   hits.push_back(*step);
   if (io) {
-    auto pos = step -> GetPreStepPoint() -> GetPosition();
-    io -> write_hit_info(0, pos.getX(), pos.getY(), pos.getZ());
+    auto pos  = step -> GetPreStepPoint() -> GetPosition();
+	auto time = step -> GetPreStepPoint() -> GetGlobalTime();
+    io -> write_hit_info(0, pos.getX(), pos.getY(), pos.getZ(), time);
   }
   return true; // TODO what is the meaning of this?
 }

--- a/abracadabra/src/geometries/sipm.hh
+++ b/abracadabra/src/geometries/sipm.hh
@@ -93,6 +93,7 @@ public:
   sipm_sensitive(G4String name)                      : G4VSensitiveDetector{name} {}
   sipm_sensitive(G4String name, std::optional<std::string> h5_name) : G4VSensitiveDetector{name}, io{h5_name} { if (io) io->open(); }
   G4bool ProcessHits(G4Step* step, G4TouchableHistory*) override;
+  void   EndOfEvent (G4HCofThisEvent*)                  override;
 
 public:
   std::vector<G4Step> hits;

--- a/abracadabra/src/geometries/sipm_hamamatsu_blue-test.cc
+++ b/abracadabra/src/geometries/sipm_hamamatsu_blue-test.cc
@@ -158,7 +158,7 @@ TEST_CASE("hamamatsu app", "[app]") {
     CHECK(row.y    == pos.getY());
     CHECK(row.z    == pos.getZ());
     CHECK(row.time == time);
-    CHECK(row.time == Approx(pos.getZ() / (CLHEP::c_light * CLHEP::ns/CLHEP::mm) ));
+    CHECK(row.time == Approx(pos.getZ() / (CLHEP::c_light / (mm/ns))));
 
     // TODO: Stupid checks, just to get something going. Replace with something
     // more intelligent

--- a/abracadabra/src/geometries/sipm_hamamatsu_blue-test.cc
+++ b/abracadabra/src/geometries/sipm_hamamatsu_blue-test.cc
@@ -14,6 +14,9 @@
 #include <G4VUserPrimaryGeneratorAction.hh>
 #include <QBBC.hh>
 
+#include <CLHEP/Units/PhysicalConstants.h>
+#include <CLHEP/Units/SystemOfUnits.h>
+
 #include <catch2/catch.hpp>
 
 #include <algorithm>
@@ -147,12 +150,15 @@ TEST_CASE("hamamatsu app", "[app]") {
   CHECK(written_hits.size() == detected_hits.size());
 
   for (auto [i, hit] : enumerate(detected_hits)) {
-    auto row =  written_hits[i];
-    auto pos = hit.GetPreStepPoint() -> GetPosition();
+    auto row  = written_hits[i];
+    auto pos  = hit.GetPreStepPoint()  -> GetPosition();
+	auto time = hit.GetPreStepPoint() -> GetGlobalTime();
     // TODO: CHECK(row.event_id == ??);
-    CHECK(row.x == pos.getX());
-    CHECK(row.y == pos.getY());
-    CHECK(row.z == pos.getZ());
+    CHECK(row.x    == pos.getX());
+    CHECK(row.y    == pos.getY());
+    CHECK(row.z    == pos.getZ());
+    CHECK(row.time == time);
+    CHECK(row.time == Approx(pos.getZ() / (CLHEP::c_light * CLHEP::ns/CLHEP::mm) ));
 
     // TODO: Stupid checks, just to get something going. Replace with something
     // more intelligent

--- a/abracadabra/src/geometries/sipm_hamamatsu_blue-test.cc
+++ b/abracadabra/src/geometries/sipm_hamamatsu_blue-test.cc
@@ -152,7 +152,7 @@ TEST_CASE("hamamatsu app", "[app]") {
   for (auto [i, hit] : enumerate(detected_hits)) {
     auto row  = written_hits[i];
     auto pos  = hit.GetPreStepPoint()  -> GetPosition();
-	auto time = hit.GetPreStepPoint() -> GetGlobalTime();
+    auto time = hit.GetPreStepPoint() -> GetGlobalTime();
     // TODO: CHECK(row.event_id == ??);
     CHECK(row.x    == pos.getX());
     CHECK(row.y    == pos.getY());

--- a/abracadabra/src/io/hdf5.cc
+++ b/abracadabra/src/io/hdf5.cc
@@ -14,7 +14,8 @@ HighFive::CompoundType create_hit_type() {
   return {{"event_id", HighFive::AtomicType<unsigned int>{}},
           {"x", HighFive::AtomicType<double>{}},
           {"y", HighFive::AtomicType<double>{}},
-          {"z", HighFive::AtomicType<double>{}}};
+          {"z", HighFive::AtomicType<double>{}},
+          {"time", HighFive::AtomicType<double>{}}};
 }
 HIGHFIVE_REGISTER_TYPE(hit_t, create_hit_type)
 
@@ -64,10 +65,10 @@ void hdf5_io::write_run_info(const char* param_key, const char* param_value) {
   runinfo_index += n_elements;
 }
 
-void hdf5_io::write_hit_info(unsigned int event_id, double x, double y, double z) {
+void hdf5_io::write_hit_info(unsigned int event_id, double x, double y, double z, double time) {
   // Create hit_t objects with the data
   std::vector<hit_t> data;
-  data.push_back({event_id, x, y, z});
+  data.push_back({event_id, x, y, z, time});
 
   unsigned int n_elements = data.size();
 

--- a/abracadabra/src/io/hdf5.hh
+++ b/abracadabra/src/io/hdf5.hh
@@ -16,6 +16,7 @@ typedef struct {
   double x;
   double y;
   double z;
+  double time;
 } hit_t;
 
 
@@ -27,7 +28,7 @@ public:
   void open();
 
   void write_run_info(const char* param_key, const char* param_value);
-  void write_hit_info(unsigned int evt_id, double x, double y, double z);
+  void write_hit_info(unsigned int evt_id, double x, double y, double z, double time);
 
   void read_hit_info(std::vector<hit_t>& hits);
 


### PR DESCRIPTION
This PR  includes several changes to the writer (split in several commits):

- Add hit's time to the hdf5 output. The test is updated to check this parameter is written properly and the time taken by the geantinos is the expected one.
- Add an event counter to the run action.

Those two first points work properly. The problem arises when I've tried to change the logic of the persistency mechanism. I think the cleanest way to do it should be to store the relevant information in the `G4Event` and then write all the information from the `event_action`.

In a more detailed way, the `G4Event` class provides a method `SetUserInformation` to store any information relevant for the user. To do that, a class derived from `G4VUserEventInformation` is required. I have created a new class named `event_data`, that currently only saves the hits from the sensitive detector. In the future more attributes could be added (particle tracks, etc.).

From `event_action::EndOfEventAction` it should be possible to call the writer to save into file all the relevant information store in the `G4VUserEventInformation` object.

Another piece needed for this to work is the method `sipm_sensitive::EndOfEvent`. This method should be called at the end of each event. At this point is where we need to store the hits into the `G4VUserEventInformation` object of the `G4Event`.

For some unknown reason this last method is **NOT** being called. Spending some hours in the most unproductive way, I've been trying to understand when G4 calls this method. Apparently the sensitive detectors have an `active` attribute that should be true for this method to work. I have tried to set it to true in our `sipm_sensitive` with no success.

There is no automated test yet for this code, I will provide it at some point.