### PR TITLE
Write LOR

### DIFF
--- a/abracadabra/abracadabra.cc
+++ b/abracadabra/abracadabra.cc
@@ -40,7 +40,7 @@ public:
     auto particle = track -> GetParticleDefinition();
     auto name     = particle -> GetParticleName();
     if (name == "gamma") {
-      std::cout << "evt: " << n4::event_number() << "\t" << name << ", added" << std::endl;
+      //std::cout << "evt: " << n4::event_number() << "\t" << name << ", added" << std::endl;
       hits.push_back(*step);
     }
     return true;
@@ -76,12 +76,13 @@ public:
           zs  .push_back(pos.z());
           ts  .push_back(time);
 
-          std::cout << std::setw (4) << event_id << ' '
-              << std::setw(15) << name << ' '
-              << std::setw (4) << id << ' '
-              << std::setw (4) << round(energy / keV) << " keV " << pos << ' '
-              << std::setw(10) << time << ' '
-              << std::endl;
+          // std::cout << std::setw (4) << event_id << ' '
+          //     << std::setw(15) << name << ' '
+          //     << std::setw (4) << id << ' '
+          //     << std::setw (4) << round(energy / keV) << " keV " << pos << ' '
+          //     << std::setw(10) << time << ' '
+          //     << std::endl;
+
       }
       writer.write_lor_info(event_id, total_energy, rs[0], phis[0], zs[0], ts[0], rs[1], phis[1], zs[1], ts[1]);
     }
@@ -259,11 +260,11 @@ int main(int argc, char** argv) {
         ui_manager->ApplyCommand("/vis/viewer/set/viewpointThetaPhi "
                                  + std::to_string(theta) + ' ' + std::to_string(phi));
       };
-      {
-        nain4::silence _{G4cout};
-        for (int phi  =PHI  ; phi  <360+PHI   ; phi  +=4) { view(THETA, phi); }
-        for (int theta=THETA; theta<360+THETAF; theta+=4) { view(theta, PHI); }
-      }
+      // {
+      //   nain4::silence _{G4cout};
+      //   for (int phi  =PHI  ; phi  <360+PHI   ; phi  +=4) { view(THETA, phi); }
+      //   for (int theta=THETA; theta<360+THETAF; theta+=4) { view(theta, PHI); }
+      // }
       ui -> SessionStart();
     }
   }

--- a/abracadabra/abracadabra.cc
+++ b/abracadabra/abracadabra.cc
@@ -72,7 +72,7 @@ public:
 
           total_energy += energy;
           rs  .push_back(r);
-          phis.push_back(time);
+          phis.push_back(phi);
           zs  .push_back(pos.z());
           ts  .push_back(time);
 

--- a/abracadabra/abracadabra.cc
+++ b/abracadabra/abracadabra.cc
@@ -115,7 +115,18 @@ int main(int argc, char** argv) {
     {G4RunManagerFactory::CreateRunManager(G4RunManagerType::Serial)};
 
   // For use with phantom_in_cylinder
-  auto phantom = a_nema_phantom();
+  auto phantom = build_nema_phantom{}
+    .activity(5)
+    .length(140*mm)
+    .inner_radius(114.4*mm)
+    .outer_radius(152.0*mm)
+    .sphere(10*mm / 2, 20)
+    .sphere(13*mm / 2, 20)
+    .sphere(17*mm / 2, 20)
+    .sphere(22*mm / 2, 20)
+    .sphere(28*mm / 2, 0)
+    .sphere(37*mm / 2, 0)
+    .build();
 
   int last_interesting_event = 0;
   size_t count_interesting_event = 0;

--- a/abracadabra/abracadabra.cc
+++ b/abracadabra/abracadabra.cc
@@ -116,7 +116,7 @@ int main(int argc, char** argv) {
 
   // For use with phantom_in_cylinder
   auto phantom = build_nema_phantom{}
-    .activity(5)
+    .activity(0)
     .length(140*mm)
     .inner_radius(58*mm)
     .outer_radius(76*mm)

--- a/abracadabra/abracadabra.cc
+++ b/abracadabra/abracadabra.cc
@@ -40,7 +40,6 @@ public:
     auto particle = track -> GetParticleDefinition();
     auto name     = particle -> GetParticleName();
     if (name == "gamma") {
-      //std::cout << "evt: " << n4::event_number() << "\t" << name << ", added" << std::endl;
       hits.push_back(*step);
     }
     return true;
@@ -75,14 +74,6 @@ public:
           phis.push_back(phi);
           zs  .push_back(pos.z());
           ts  .push_back(time);
-
-          // std::cout << std::setw (4) << event_id << ' '
-          //     << std::setw(15) << name << ' '
-          //     << std::setw (4) << id << ' '
-          //     << std::setw (4) << round(energy / keV) << " keV " << pos << ' '
-          //     << std::setw(10) << time << ' '
-          //     << std::endl;
-
       }
       writer.write_lor_info(event_id, total_energy, rs[0], phis[0], zs[0], ts[0], rs[1], phis[1], zs[1], ts[1]);
     }

--- a/abracadabra/abracadabra.cc
+++ b/abracadabra/abracadabra.cc
@@ -68,7 +68,7 @@ public:
           auto time     = track -> GetGlobalTime();
 
           auto r   = sqrt( pos.x()*pos.x() + pos.y()*pos.y() );
-          auto phi = atan( pos.y() / pos.x() );
+          auto phi = atan2( pos.y(), pos.x() );
 
           total_energy += energy;
           rs  .push_back(r);

--- a/abracadabra/abracadabra.cc
+++ b/abracadabra/abracadabra.cc
@@ -118,14 +118,14 @@ int main(int argc, char** argv) {
   auto phantom = build_nema_phantom{}
     .activity(5)
     .length(140*mm)
-    .inner_radius(114.4*mm)
-    .outer_radius(152.0*mm)
-    .sphere(10*mm / 2, 20)
-    .sphere(13*mm / 2, 20)
-    .sphere(17*mm / 2, 20)
-    .sphere(22*mm / 2, 20)
-    .sphere(28*mm / 2, 0)
-    .sphere(37*mm / 2, 0)
+    .inner_radius(58*mm)
+    .outer_radius(76*mm)
+    .sphere( 5  *mm / 2, 20)
+    .sphere( 6.5*mm / 2, 20)
+    .sphere( 8.5*mm / 2, 20)
+    .sphere(11  *mm / 2, 20)
+    .sphere(14  *mm / 2, 0)
+    .sphere(19  *mm / 2, 0)
     .build();
 
   int last_interesting_event = 0;

--- a/abracadabra/src/geometries/samples.cc
+++ b/abracadabra/src/geometries/samples.cc
@@ -56,7 +56,7 @@ G4VPhysicalVolume* cylinder_lined_with_hamamatsus(double length, double radius, 
 
   auto cavity_r = radius - dr_Xe;
 
-  auto xenon    = volume<G4Tubs>("LXe"     , lXe, cavity_r,   radius, length/2, 0.0, CLHEP::twopi);
+  auto xenon    = volume<G4Tubs>("LXe"     , air, cavity_r,   radius, length/2, 0.0, CLHEP::twopi);
   auto cavity   = volume<G4Tubs>("Cavity"  , air, 0.0     , cavity_r, length/2, 0.0, CLHEP::twopi);
   auto envelope = volume<G4Box> ("Envelope", air, 1.1*radius, 1.1*radius, 1.1*length/2);
 

--- a/abracadabra/src/geometries/samples.hh
+++ b/abracadabra/src/geometries/samples.hh
@@ -5,6 +5,6 @@
 
 nema_phantom       a_nema_phantom();
 G4VPhysicalVolume* square_array_of_sipms(G4VSensitiveDetector* = nullptr);
-G4VPhysicalVolume* phantom_in_cylinder(nema_phantom const&, double, double, G4VSensitiveDetector* = nullptr);
+G4VPhysicalVolume* phantom_in_cylinder(nema_phantom const&, G4double length, G4double dr_Xe, G4VSensitiveDetector* = nullptr);
 G4VPhysicalVolume* cylinder_lined_with_hamamatsus(double length, double radius, double dr_Xe,
                                                   G4VSensitiveDetector* = nullptr);

--- a/abracadabra/src/io/hdf5.hh
+++ b/abracadabra/src/io/hdf5.hh
@@ -19,6 +19,30 @@ typedef struct {
   double t;
 } hit_t;
 
+typedef struct {
+  double event_id;
+  double true_energy;
+  double true_r1;
+  double true_phi1;
+  double true_z1;
+  double true_t1;
+  double true_r2;
+  double true_phi2;
+  double true_z2;
+  double true_t2;
+  double phot_like1;
+  double phot_like2;
+  double reco_r1;
+  double reco_phi1;
+  double reco_z1;
+  double reco_t1;
+  double reco_r2;
+  double reco_phi2;
+  double reco_z2;
+  double reco_t2;
+  double not_sel;
+} lor_t;
+
 
 // TODO There's something fishy about the implementation behind this interface:
 // it holds on to a filename, and then opens the file each time it wants to
@@ -30,6 +54,9 @@ public:
 
   void write_run_info(const char* param_key, const char* param_value);
   void write_hit_info(unsigned int evt_id, double x, double y, double z, double t);
+  void write_lor_info(double event_id, double energy,
+          double r1, double phi1, double z1, double t1,
+          double r2, double phi2, double z2, double t2);
   void flush() { if (open_for_writing) { open_for_writing -> flush(); } }
 
   std::vector<hit_t> read_hit_info();
@@ -42,6 +69,7 @@ private:
   std::string filename;
   unsigned int runinfo_index;
   unsigned int hit_index;
+  unsigned int lor_index;
   std::optional<HighFive::File> open_for_writing;
 };
 
@@ -50,6 +78,5 @@ typedef struct {
   char param_key  [hdf5_io::CONFLEN];
   char param_value[hdf5_io::CONFLEN];
 } run_info_t;
-
 
 #endif


### PR DESCRIPTION
This PR is a simple (and dirty) way if writing LORs into HDF5. LXe has been replaced by air and only events with 2 gammas will be written. I still need to define a way to pass the output filename in the configuration file.

In any case, I have not been able to read with `petalo_rust` a sample file produced with this PR. The HDF5 file can be read without error with different tools (`h5ls`, `hdfview`, `python`), but the rust code shows this error:

```
$ cargo run --bin mlem --release -- -i 6 -r 20 -f data/in/test_lor.h5 
    Finished release [optimized + debuginfo] target(s) in 0.11s
     Running `target/release/mlem -i 6 -r 20 -f data/in/test_lor.h5`
Float precision: 32 bits
Error: slice extends beyond dataspace bounds
```

I have included in a commit the same file I've used. Can you check if you can run the rust code with this file?


